### PR TITLE
Always propagate right-side y-axis

### DIFF
--- a/acispy/plots.py
+++ b/acispy/plots.py
@@ -274,7 +274,7 @@ class CustomDatePlot(ACISPlot):
         """
         if dates.dtype.char in ['S', 'U']:
             dates = date2secs(dates)
-        if not hasattr(self, "ax2"):
+        if self.ax2 is None:
             self.ax2 = self.ax.twinx()
             self.ax2.set_zorder(-10)
             self.ax.patch.set_visible(False)


### PR DESCRIPTION
A `DatePlot` or `CustomDatePlot` object can always have a right-side y-axis for a separate quantity, and it is also true that both of these objects can share another object's `Figure` and `Axes` objects. This PR ensures that the right-side y-axis is also always shared.